### PR TITLE
nfc: Fix warning when the GPIO is on a I2C chip

### DIFF
--- a/pn5xx_i2c.c
+++ b/pn5xx_i2c.c
@@ -144,8 +144,8 @@ static int pn544_enable(struct pn54x_dev *dev, int mode)
 	if (MODE_RUN == mode) {
 		pr_info("%s power on\n", __func__);
 		if (gpio_is_valid(dev->firm_gpio))
-			gpio_set_value(dev->firm_gpio, 0);
-		gpio_set_value(dev->ven_gpio, 1);
+			gpio_set_value_cansleep(dev->firm_gpio, 0);
+		gpio_set_value_cansleep(dev->ven_gpio, 1);
 		msleep(100);
 	}
 	else if (MODE_FW == mode) {
@@ -189,8 +189,8 @@ static void pn544_disable(struct pn54x_dev *dev)
 	/* power off */
 	pr_info("%s power off\n", __func__);
 	if (gpio_is_valid(dev->firm_gpio))
-		gpio_set_value(dev->firm_gpio, 0);
-	gpio_set_value(dev->ven_gpio, 0);
+		gpio_set_value_cansleep(dev->firm_gpio, 0);
+	gpio_set_value_cansleep(dev->ven_gpio, 0);
 	msleep(100);
 
 	if(dev->sevdd_reg) regulator_disable(dev->sevdd_reg);


### PR DESCRIPTION
The following warning is showed several times when the pn5xx_i2c
is used in combination with nfcDemoapp:

pn54x_dev_ioctl, cmd=1074063617, arg=0
pn544_disable power off
------------[ cut here ]------------
WARNING: CPU: 0 PID: 681 at drivers/gpio/gpiolib.c:1377 gpiod_set_raw_value+0x54/0x58()
Modules linked in: ov5640_camera_mipi pn5xx_i2c mxc_mipi_csi mx6s_capture
CPU: 0 PID: 681 Comm: nfcDemoApp Tainted: G        W       4.1.15+gb63f3f5 #4
Hardware name: Freescale i.MX7 Dual (Device Tree)
[<80015d78>] (unwind_backtrace) from [<8001271c>] (show_stack+0x10/0x14)
[<8001271c>] (show_stack) from [<807f45a8>] (dump_stack+0x84/0xc4)
[<807f45a8>] (dump_stack) from [<800357e0>] (warn_slowpath_common+0x80/0xb0)
[<800357e0>] (warn_slowpath_common) from [<800358ac>] (warn_slowpath_null+0x1c/0x24)
[<800358ac>] (warn_slowpath_null) from [<802ddf18>] (gpiod_set_raw_value+0x54/0x58)
[<802ddf18>] (gpiod_set_raw_value) from [<7f00f400>] (pn54x_dev_ioctl+0xd8/0x1e8 [pn5xx_i2c])
[<7f00f400>] (pn54x_dev_ioctl [pn5xx_i2c]) from [<800fabf4>] (do_vfs_ioctl+0x3e8/0x608)
[<800fabf4>] (do_vfs_ioctl) from [<800fae48>] (SyS_ioctl+0x34/0x5c)
[<800fae48>] (SyS_ioctl) from [<8000f480>] (ret_fast_syscall+0x0/0x3c)
---[ end trace 51eab9387f6c81ba ]---

Fix this by using gpio_set_value_cansleep() as suggested in
drivers/gpio/gpiolib.c:1377, for power on/off functions.

Signed-off-by: marco <marco.franchi@nxp.com>