### PR TITLE
Correct pr-warning

### DIFF
--- a/pn5xx_i2c.c
+++ b/pn5xx_i2c.c
@@ -238,7 +238,7 @@ static ssize_t pn54x_dev_read(struct file *filp, char __user *buf,
 			if (gpio_get_value(pn54x_dev->irq_gpio))
 				break;
 
-			pr_warning("%s: spurious interrupt detected\n", __func__);
+			pr_warn("%s: spurious interrupt detected\n", __func__);
 		}
 	}
 
@@ -261,7 +261,7 @@ static ssize_t pn54x_dev_read(struct file *filp, char __user *buf,
 		return -EIO;
 	}
 	if (copy_to_user(buf, tmp, ret)) {
-		pr_warning("%s : failed to copy to user space\n", __func__);
+		pr_warn("%s : failed to copy to user space\n", __func__);
 		return -EFAULT;
 	}
 	return ret;


### PR DESCRIPTION
pr_warning function is not defined. The compiler shows the error:

> pn5xx_i2c.c:241:25: error: implicit declaration of function 'pr_warning'; did you mean 'acpi_warning'? [-Werror=implicit-function-declaration]
> |   241 |                         pr_warning("%s: spurious interrupt detected\n", __func__);
> |       |                         ^~~~~~~~~~
> |       |                         acpi_warning
> | cc1: some warnings being treated as errors

the name of the function is **pr_warn**